### PR TITLE
Adding option timeout param

### DIFF
--- a/callofduty/auth.py
+++ b/callofduty/auth.py
@@ -29,14 +29,14 @@ class Auth:
     _accessToken: Optional[str] = None
     _deviceId: Optional[str] = None
 
-    def __init__(self, email: str, password: str):
+    def __init__(self, email: str, password: str, read_timeout: int = 10):
         self.email: str = email
         self.password: str = password
 
         # Certain endpoints, such as the one used by GetPlayerLoadouts,
-        # take a bit longer to recieve data; Hence the increased read_timeout.
+        # take a bit longer to recieve data; hence optional param defaulted to 10.
         self.session: httpx.AsyncClient = httpx.AsyncClient(
-            timeout=httpx.Timeout(read_timeout=10)
+            timeout=httpx.Timeout(read_timeout=read_timeout)
         )
 
     @property


### PR DESCRIPTION
Occasionally hitting some read_timeouts and would like to extend this.

### Summary

<!-- What is this Pull Request for? Does it fix any Issues? -->
Some of the API calls take a while to respond.
The timeout is currently set to 10. I'd like this to be an optional param that can be extended.

I haven't got an easy way to test this sadly :-(

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

-   [] If code changes were made then they have been tested (...sorry)
-   [] I have updated the documentation to reflect the changes
-   [] This Pull Request fixes an Issue
-   [X ] This Pull Request adds something new (e.g. new method or parameters)
-   [ ] This Pull Request is a breaking change (e.g. methods or parameters removed/renamed)
-   [ ] This Pull Request is not a code change (e.g. Documentation or README)
