### PR TITLE
Using new Endpoint URL

### DIFF
--- a/callofduty/http.py
+++ b/callofduty/http.py
@@ -50,7 +50,7 @@ class Request:
         JSON data to include in the body of the request (default is None.)
     """
 
-    defaultBaseUrl: str = "https://callofduty.com/"
+    defaultBaseUrl: str = "https://www.callofduty.com/"
     myBaseUrl: str = "https://my.callofduty.com/"
     squadsBaseUrl: str = "https://squads.callofduty.com/"
 


### PR DESCRIPTION
The endpoint is being redirected, therefore using the new one as baseUrl.

See debug, before:
DEBUG:httpx._client:HTTP Request: GET https://callofduty.com/api/papi-client/ce/v1/title/mw/platform/uno/match/5848103427243427739/matchMapEvents "HTTP/1.1 301 Moved Permanently"
DEBUG:httpx._client:HTTP Request: GET https://www.callofduty.com/api/papi-client/ce/v1/title/mw/platform/uno/match/5848103427243427739/matchMapEvents "HTTP/1.1 200 OK"

### Summary

<!-- What is this Pull Request for? Does it fix any Issues? -->

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

-   [x] If code changes were made then they have been tested
    -   [x] I have updated the documentation to reflect the changes
-   [x] This Pull Request fixes an Issue
-   [ ] This Pull Request adds something new (e.g. new method or parameters)
-   [ ] This Pull Request is a breaking change (e.g. methods or parameters removed/renamed)
-   [ ] This Pull Request is not a code change (e.g. Documentation or README)
