### PR TITLE
Add support for the fullMatch endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # Incomplete
 tests/
 docs/
+
+# PyCharm/IntelliJ IDEA
+.idea

--- a/callofduty/client.py
+++ b/callofduty/client.py
@@ -623,6 +623,37 @@ class Client:
             self, {"id": matchId, "platform": platform.value, "title": title.value,},
         )
 
+    async def GetFullMatch(
+        self, title: Title, platform: Platform, mode: Mode, matchId: int
+    ) -> dict:
+        """
+            Get a Call of Duty match using its title, platform, mode, and ID.
+
+            Parameters
+            ----------
+            title : callofduty.Title
+                Call of Duty title which the match occured on.
+            platform : callofduty.Platform
+                Platform to get the player from.
+            mode : str
+            matchId : int
+                Match ID.
+
+            Returns
+            -------
+            object
+                Match object representing the specified details.
+            """
+
+        VerifyTitle(title)
+        VerifyPlatform(platform)
+
+        return (
+            await self.http.GetFullMatch(
+                title.value, platform.value, mode.value, matchId
+            )
+        )["data"]
+
     async def GetPlayerMatches(
         self, platform: Platform, username: str, title: Title, mode: Mode, **kwargs
     ) -> List[Match]:

--- a/callofduty/http.py
+++ b/callofduty/http.py
@@ -267,6 +267,16 @@ class HTTP:
             )
         )
 
+    async def GetFullMatch(
+        self, title: str, platform: str, mode: str, matchId: int,
+    ) -> Union[dict, list, str]:
+        return await self.Send(
+            Request(
+                "GET",
+                f"api/papi-client/crm/cod/v2/title/{title}/platform/{platform}/fullMatch/{mode}/{matchId}/en",
+            )
+        )
+
     async def GetLeaderboard(
         self,
         title: str,

--- a/test.py
+++ b/test.py
@@ -126,6 +126,13 @@ async def main():
     # details = await match.details()
     # print(details)
 
+    # player = await client.GetPlayer(Platform.Activision, "toomanytacos#5120625")
+    # match = (await player.matches(Title.ModernWarfare, Mode.Warzone, limit=3))[1]
+    # full_match = await client.GetFullMatch(
+    #     Title.ModernWarfare, Platform.Activision, Mode.Warzone, match.id
+    # )
+    # print(full_match)
+
     # results = await client.SearchPlayers(Platform.Activision, "Tustin")
     # for player in results:
     #     print(f"{player.username} ({player.platform.name})")


### PR DESCRIPTION
### Summary

Adds support for the fullMatch endpoint:

- `api/papi-client/crm/cod/v2/title/{title}/platform/{platform}/fullMatch/{mode}/{matchId}/en`

It might help with these issues:

- https://github.com/EthanC/CallofDuty.py/issues/33
- https://github.com/EthanC/CallofDuty.py/issues/18

Also added an example in `test.py`.

I should have opened an issue first, but I'm okay with this being a starting point to a better implementation and not being merged. 

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

-   [x] If code changes were made then they have been tested
    -   [ ] I have updated the documentation to reflect the changes
-   [ ] This Pull Request fixes an Issue
-   [x] This Pull Request adds something new (e.g. new method or parameters)
-   [ ] This Pull Request is a breaking change (e.g. methods or parameters removed/renamed)
-   [ ] This Pull Request is not a code change (e.g. Documentation or README)
