### PR TITLE
Add exception for failed (but HTTP 200) log ins

### DIFF
--- a/callofduty/auth.py
+++ b/callofduty/auth.py
@@ -6,7 +6,7 @@ import httpx
 
 from .client import Client
 from .errors import LoginFailure
-from .http import HTTP
+from .http import HTTP, JSONorText
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -107,6 +107,13 @@ class Auth:
 
             if res.status_code != 200:
                 raise LoginFailure(f"Failed to login (HTTP {res.status_code})")
+
+            if isinstance(data := await JSONorText(res), dict):
+                success: Optional[bool] = data.get("success")
+
+                # The API tends to return HTTP 200 even when an error occurs
+                if not success:
+                    raise LoginFailure(f"Failed to login (error '{data.get('error')}')")
 
 
 async def Login(email: str, password: str) -> Client:


### PR DESCRIPTION
### Summary

This updates the login method to throw an exception in the case where the `/cod/mapp/login` endpoint returns `200 OK`, but contains an error response.

Addresses #68. 

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

-   [x] If code changes were made then they have been tested
    -   [ ] I have updated the documentation to reflect the changes
-   [x] This Pull Request fixes an Issue
-   [ ] This Pull Request adds something new (e.g. new method or parameters)
-   [ ] This Pull Request is a breaking change (e.g. methods or parameters removed/renamed)
-   [ ] This Pull Request is not a code change (e.g. Documentation or README)
