### PR TITLE
Cookie authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ from callofduty import Mode, Platform, Title
 async def main():
     client = await callofduty.Login("YourEmail@email.com", "YourPassword")
 
+    # Or you can authenticate using your `ACT_SSO_COOKIE`, pulled from a browser session
+    # client = await callofduty.Cookie("ACT_SSO_COOKIE value")
+
     results = await client.SearchPlayers(Platform.Activision, "Captain Price", limit=3)
     for player in results:
         print(f"{player.username} ({player.platform.name})")

--- a/callofduty/__init__.py
+++ b/callofduty/__init__.py
@@ -7,7 +7,7 @@ GitHub: https://github.com/EthanC/CallofDuty.py
 
 import logging
 
-from .auth import Login
+from .auth import Login, Cookie
 from .client import Client
 from .enums import *
 from .errors import *

--- a/callofduty/auth.py
+++ b/callofduty/auth.py
@@ -112,6 +112,22 @@ class Auth:
                 raise LoginFailure(f"Failed to login (HTTP {res.status_code})")
 
 
+class CookieAuth:
+    """
+    Holds cookie authentication token in a httpx session.
+
+    Parameters
+    ----------
+    token : str
+        ACT_SSO_COOKIE value
+    """
+
+    def __init__(self, token: str):
+        self.session: httpx.AsyncClient = httpx.AsyncClient(cookies={
+            "ACT_SSO_COOKIE": token
+        })
+
+
 async def Login(email: str, password: str) -> Client:
     """
     Convenience function to make login with the Call of Duty authorization flow
@@ -133,5 +149,12 @@ async def Login(email: str, password: str) -> Client:
     auth: Auth = Auth(email, password)
 
     await auth.SubmitLogin()
+
+    return Client(HTTP(auth))
+
+
+async def Cookie(token: str) -> Client:
+
+    auth: CookieAuth = CookieAuth(token)
 
     return Client(HTTP(auth))

--- a/callofduty/auth.py
+++ b/callofduty/auth.py
@@ -33,7 +33,10 @@ class Auth:
         self.email: str = email
         self.password: str = password
         
-        self.session: httpx.AsyncClient = httpx.AsyncClient()
+        self.session: httpx.AsyncClient = httpx.AsyncClient(headers={
+            "x_cod_device_id": self.DeviceId,
+            "Authorization": f"Bearer {self.AccessToken}",
+        })
 
     @property
     def AccessToken(self) -> Optional[str]:
@@ -61,7 +64,7 @@ class Auth:
         """
 
         if self._deviceId is None:
-            raise LoginFailure("DeviceId is null, not authenticated")
+            self.RegisterDevice()
 
         return self._deviceId
 
@@ -129,7 +132,6 @@ async def Login(email: str, password: str) -> Client:
 
     auth: Auth = Auth(email, password)
 
-    await auth.RegisterDevice()
     await auth.SubmitLogin()
 
     return Client(HTTP(auth))

--- a/callofduty/http.py
+++ b/callofduty/http.py
@@ -96,9 +96,6 @@ class HTTP:
             Response of the HTTP request.
         """
 
-        req.SetHeader("Authorization", f"Bearer {self.auth.AccessToken}")
-        req.SetHeader("x_cod_device_id", self.auth.DeviceId)
-
         async with self.session as client:
             res: Response = await client.request(
                 req.method, req.url, headers=req.headers, json=req.json

--- a/test.py
+++ b/test.py
@@ -9,8 +9,12 @@ from callofduty import Mode, Platform, Reaction, Title
 
 async def main():
     load_dotenv()
-    client = await callofduty.Login(
-        os.environ["ATVI_EMAIL"], os.environ["ATVI_PASSWORD"]
+    # client = await callofduty.Login(
+    #     os.environ["ATVI_EMAIL"], os.environ["ATVI_PASSWORD"]
+    # )
+
+    client = await callofduty.Cookie(
+        os.environ["ATVI_ACT_SSO_COOKIE"]
     )
 
     # season = await client.GetLootSeason(Title.BlackOps4, 3)


### PR DESCRIPTION
### Summary

This adds a new method of authenticating with the API. The API can be accessed by providing the `ACT_SSO_COOKIE` cookie. This cookie can be obtained by logging in to callofduty.com using a web browser, then manually extracting it using your browsers developer tools. While not perfect, it can work as a work around because of the current issues.

The branch is open for edits by maintainers, if you want to move anything around, feel free. I'm happy to make changes here. I've included the new `CookieAuth` in `auth.py`, but I can extract this out. I've called the new method `Cookie`, but I'm happy for that to be changed.

I've also moved setting the headers from the old authentication flow into the `Auth` class. This way the http calls aren't concered with authentication.

Addresses #68.

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

-   [x] If code changes were made then they have been tested
    -   [x] I have updated the documentation to reflect the changes
-   [ ] This Pull Request fixes an Issue
-   [x] This Pull Request adds something new (e.g. new method or parameters)
-   [ ] This Pull Request is a breaking change (e.g. methods or parameters removed/renamed)
-   [ ] This Pull Request is not a code change (e.g. Documentation or README)
