### PR TITLE
fix black ops 4 and blackout profile request

### DIFF
--- a/callofduty/utils.py
+++ b/callofduty/utils.py
@@ -62,7 +62,7 @@ def VerifyMode(value: Mode, title: Title):
         raise InvalidMode(f"{value.name} is not a valid mode")
     elif (value == Mode.Zombies) and (title == Title.ModernWarfare):
         raise InvalidMode(f"{value.name} is not a valid mode for title {title.name}")
-    elif (value == Mode.Warzone) and (title != Title.ModernWarfare):
+    elif (value == Mode.Warzone) and not (title == Title.ModernWarfare or title == Title.BlackOps4):
         raise InvalidMode(f"{value.name} is not a valid mode for title {title.name}")
 
 


### PR DESCRIPTION
### Summary

Fix an issue where Blackout is selected, because ``Mode.Blackout == Mode.Warzone``

### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

-   [x] If code changes were made then they have been tested
    -   [ ] I have updated the documentation to reflect the changes
-   [x] This Pull Request fixes an Issue
-   [ ] This Pull Request adds something new (e.g. new method or parameters)
-   [ ] This Pull Request is a breaking change (e.g. methods or parameters removed/renamed)
-   [ ] This Pull Request is not a code change (e.g. Documentation or README)
